### PR TITLE
fix: add missing rule for arrow function parenthesis

### DIFF
--- a/config/prettier/.prettierrc.js
+++ b/config/prettier/.prettierrc.js
@@ -2,6 +2,7 @@ module.exports = {
   semi: true,
   trailingComma: "all",
   singleQuote: true,
+  arrowParens: "always",
   printWidth: 100,
   tabWidth: 2
 };


### PR DESCRIPTION
According to airbnb style guide https://github.com/airbnb/javascript#arrows--one-arg-parens