### PR TITLE
fix(rules): ignore ts declaration files

### DIFF
--- a/boilerplate/.eslintignore
+++ b/boilerplate/.eslintignore
@@ -1,1 +1,2 @@
 serviceWorker.*
+*.d.ts


### PR DESCRIPTION
When you run `yarn code:clean` eslint will get the `react-app-env.d.ts` file and break it... 

In this PR I just add [declaration files](https://en.wikipedia.org/wiki/TypeScript#Declaration_files) to `.eslintignore`

