### PR TITLE
chore(prettier): drop default prettier options

### DIFF
--- a/config/prettier/.prettierrc.js
+++ b/config/prettier/.prettierrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  semi: true,
   trailingComma: "all",
   singleQuote: true,
   arrowParens: "always",
-  printWidth: 100,
-  tabWidth: 2
+  printWidth: 100
 };


### PR DESCRIPTION
https://prettier.io/docs/en/options.html#semicolons and https://prettier.io/docs/en/options.html#tab-width are already the defaults