### PR TITLE
feat(cli): add skipInstall flag that will skip installing poetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ On the root of your project run:
 npx poetic
 ```
 
+### CLI flags:
+<dl>
+  <dt>--keeprules=true</dt>
+  <dd>This will keep your current configuration files as is.</dd>
+  <dt>--local=true</dt>
+  <dd>Will install poetic from the local parent directory.</dd>
+  <dt>--skipinstall=true</dt>
+  <dd>Will skip installing poetic as a dependency.</dd>
+</dl>
+
 > Trying out Poetic is safe! You can review all the changes in Git before committing. If you don't like it, just discard it.
 
 ## Features

--- a/bin/install.js
+++ b/bin/install.js
@@ -10,6 +10,7 @@ const sourceRootDir = path.join(__dirname, "..");
 
 const isInLocalMode = argv.local;
 const keepRules = argv.keeprules;
+const skipInstall = argv.skipinstall;
 
 
 const resetChanges = () => {
@@ -91,13 +92,15 @@ const updatePackageJson = () => {
 }
 
 const installPackages = () => {
+  if (skipInstall !== 'true') {
     try {
       console.log('🥭 Installing packages ...');
-      const source = isInLocalMode ? '../poetic' : 'poetic'
+      const source = isInLocalMode ? '../poetic' : 'poetic';
       cp.execSync(`yarn add ${source} --dev`);
     } catch (e) {
       throw Error(`Could not install packages.`);
     }
+  }
 }
 
 const displaySuccessMessage = () => {


### PR DESCRIPTION
The motivation for this feature is that I would like to extend on poetic in a new npm package. I will be using poetic's install script and boilerplated-rules in the background, but need a way to skip installing the package since it will a nested dependency instead.

Also added documentation for all the other cli flags.